### PR TITLE
Fixing .site-overlay not displaying

### DIFF
--- a/css/pushy.css
+++ b/css/pushy.css
@@ -77,6 +77,7 @@
 
 .site-overlay{
     display: none;
+    min-height: 100%;
 }
 
 .pushy-active .site-overlay{


### PR DESCRIPTION
Oddly, .site-overlay was not displaying when the menu was toggled, even with.
{ position: abolsute; left: 0; right: 0; top: 0; bottom: 0 }
So with a mobile or with my desktop browser I was able to scroll left-to-right in #container.

I fixed it adding a simple {min-height: 100%}
