### PR TITLE
Make jQuery fallbacks state logic less confusing

### DIFF
--- a/js/pushy.js
+++ b/js/pushy.js
@@ -80,27 +80,27 @@ $(function() {
 		container.css({"overflow-x": "hidden"}); //fixes IE scrollbar issue
 
 		//keep track of menu state (open/close)
-		var state = true;
+		var opened = false;
 
 		//toggle menu
 		menuBtn.click(function() {
-			if (state) {
-				openPushyFallback();
-				state = false;
-			} else {
+			if (opened) {
 				closePushyFallback();
-				state = true;
+				opened = false;
+			} else {
+				openPushyFallback();
+				opened = true;
 			}
 		});
 
 		//close menu when clicking site overlay
 		siteOverlay.click(function(){ 
-			if (state) {
-				openPushyFallback();
-				state = false;
-			} else {
+			if (opened) {
 				closePushyFallback();
-				state = true;
+				opened = false;
+			} else {
+				openPushyFallback();
+				opened = true;
 			}
 		});
 	}


### PR DESCRIPTION
When we're opened, we should close it, and set the state to false. This
makes the code much more readable and sensible.