### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "christophery <@cmyee>"
   ],
   "description": "Pushy is a responsive off-canvas navigation menu using CSS transforms & transitions.",
-  "main": ["js/pushy.js", "css/pushy.css"],
+  "main": ["js/pushy.js", "scss/pushy.scss"],
   "keywords": [
     "jquery",
     "offcanvas",


### PR DESCRIPTION
to compile the original .scss file instead of the css/pushy.css file. This will enable the overriding of the $menu_width variable, if you merge https://github.com/christophery/pushy/pull/89