### PR TITLE
Allow Multiple Pushy Menus with Different Buttons

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -135,7 +135,7 @@
         <!-- Site Overlay -->
         <div class="site-overlay"></div>
 
-        <!-- Oxibug Modifications -->
+        <!-- Two Different Trigger buttons Example -->
         <div id="container">
             <!-- Menu Button -->
             <div class="wrp-pushy-trigger" data-pushy-target=".pushy-for-button-one" data-pushy-body-class="pushy-sidemenu-one another-class-one">

--- a/demo.html
+++ b/demo.html
@@ -20,7 +20,7 @@
         <header class="site-header push">This is a header</header>
 
         <!-- Pushy Menu -->
-        <nav class="pushy pushy-left" data-focus="#first-link">
+        <nav class="pushy pushy-left pushy-for-button-one" data-focus="#first-link">
             <div class="pushy-content">
                 <ul>
                     <li class="pushy-submenu">
@@ -76,14 +76,77 @@
             </div>
         </nav>
 
+        <nav class="pushy pushy-right pushy-for-button-two" data-focus="#second-link">
+            <div class="pushy-content">
+                <ul>
+                    <li class="pushy-submenu">
+                        <button id="second-link">Submenu 1</button>
+                        <ul>
+                            <li class="pushy-submenu">
+                                <button>Sub-Submenu 1</button>
+                                <ul>
+                                    <li class="pushy-link"><a href="#">Item 1</a></li>
+                                    <li class="pushy-link"><a href="#">Item 2</a></li>
+                                </ul>
+                            </li>
+                            <li class="pushy-submenu">
+                                <button>Sub-Submenu 2</button>
+                                <ul>
+                                    <li class="pushy-link"><a href="#">Item 1</a></li>
+                                    <li class="pushy-link"><a href="#">Item 2</a></li>
+                                </ul>
+                            </li>
+                            <li class="pushy-link"><a href="#">Item 1</a></li>
+                            <li class="pushy-link"><a href="#">Item 2</a></li>
+                        </ul>
+                    </li>
+                    <li class="pushy-submenu">
+                        <button>Submenu 2</button>
+                        <ul>
+                            <li class="pushy-link"><a href="#">Item 1</a></li>
+                            <li class="pushy-link"><a href="#">Item 2</a></li>
+                            <li class="pushy-link"><a href="#">Item 3</a></li>
+                        </ul>
+                    </li>
+                    <li class="pushy-submenu">
+                        <button>Submenu 3</button>
+                        <ul>
+                            <li class="pushy-link"><a href="#">Item 1</a></li>
+                            <li class="pushy-link"><a href="#">Item 2</a></li>
+                            <li class="pushy-link"><a href="#">Item 3</a></li>
+                        </ul>
+                    </li>
+                    <li class="pushy-submenu">
+                        <button>Submenu 4</button>
+                        <ul>
+                            <li class="pushy-link"><a href="#">Item 1</a></li>
+                            <li class="pushy-link"><a href="#">Item 2</a></li>
+                            <li class="pushy-link"><a href="#">Item 3</a></li>
+                        </ul>
+                    </li>
+                    <li class="pushy-link"><a href="#">Item 1</a></li>
+                    <li class="pushy-link"><a href="#">Item 2</a></li>
+                    <li class="pushy-link"><a href="#">Item 3</a></li>
+                    <li class="pushy-link"><a href="#">Item 4</a></li>
+                </ul>
+            </div>
+        </nav>
+
         <!-- Site Overlay -->
         <div class="site-overlay"></div>
 
-        <!-- Your Content -->
+        <!-- Oxibug Modifications -->
         <div id="container">
             <!-- Menu Button -->
-            <button class="menu-btn">&#9776; Menu</button>
+            <div class="wrp-pushy-trigger" data-pushy-target=".pushy-for-button-one" data-pushy-body-class="pushy-sidemenu-one another-class-one">
+                <button class="menu-btn">&#9776; Menu 1</button>
+            </div>
+            
+            <div class="wrp-pushy-trigger" data-pushy-target=".pushy-for-button-two" data-pushy-body-class="pushy-sidemenu-two another-class-two">
+                <a href="#" class="menu-btn">&#9776; Menu 2</a>
+            </div>
 
+            
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pharetra neque a diam cursus pulvinar. Suspendisse faucibus mi id accumsan lobortis. Pellentesque consectetur varius turpis, nec viverra justo pellentesque sit amet. Vestibulum convallis leo non purus vehicula, non faucibus libero rhoncus. Morbi aliquam tincidunt facilisis. Aenean sodales nulla ac semper consectetur. Vivamus commodo massa convallis justo posuere vestibulum. Aenean congue non mauris ac auctor. Ut suscipit et eros nec suscipit. Nulla congue, mauris nec bibendum sagittis, urna orci tincidunt massa, in vulputate velit nulla vitae nunc. Etiam urna justo, imperdiet nec orci sollicitudin, tempus feugiat erat. Vivamus id lectus nulla. Vestibulum sagittis cursus metus vel ultricies. <a href="https://github.com/christophery/pushy">Suspendisse viverra</a> interdum metus eu placerat. Quisque tristique velit nisi, scelerisque consectetur tortor vehicula ut. Donec id fermentum mi, nec venenatis felis.</p>
 
             <p>Praesent id metus imperdiet, congue leo sed, eleifend purus. Donec congue scelerisque tempus. Maecenas eget nunc pharetra, laoreet enim sed, dictum odio. Sed non mollis purus. Aliquam aliquet, risus eget dictum commodo, neque mi dapibus ipsum, tempus iaculis elit lorem pharetra mauris. Vivamus pulvinar scelerisque lectus a congue. Sed vitae odio massa. Pellentesque condimentum sit amet arcu in convallis.</p>
@@ -101,7 +164,7 @@
         <footer class="site-footer push">This is a footer</footer>
 
         <!-- Pushy JS -->
-        <script src="js/pushy.min.js"></script>
+        <script src="js/pushy.js"></script>
 
     </body>
 </html>


### PR DESCRIPTION
We've made some changes to enable using multiple buttons to trigger multiple different menus.

### Added Classes:
**wrp-pushy-trigger**: to wrap the [menu-btn] inside it and to define the new data attributes

### Added Data Attributes:
**data-pushy-target**: define the target menu unique class.
**data-pushy-body-class**: add some unique classes to the body selector.

### Example:
```html
<nav class="pushy pushy-left pushy-for-button-one">
    <div class="pushy-content">
    .....
    </div>
</nav>

<nav class="pushy pushy-right pushy-for-button-two">
    <div class="pushy-content">
    .....
    </div>
</nav>

<div class="wrp-pushy-trigger" data-pushy-target=".pushy-for-button-one" data-pushy-body-class="pushy-sidemenu-one another-class-one">
    <button class="menu-btn">Menu 1</button>
</div>

<div class="wrp-pushy-trigger" data-pushy-target=".pushy-for-button-two" data-pushy-body-class="pushy-sidemenu-two another-class-two">
    <button href="#" class="menu-btn">Menu 2</button>
</div>
```